### PR TITLE
Feat/find schedule

### DIFF
--- a/src/main/java/com/example/schedulemanagementapi/controller/ScheduleController.java
+++ b/src/main/java/com/example/schedulemanagementapi/controller/ScheduleController.java
@@ -32,4 +32,10 @@ public class ScheduleController {
         return new ResponseEntity<>(scheduleService.findAllSchedules(), HttpStatus.OK);
     }
 
+    @GetMapping("{id}")
+    public ResponseEntity<ScheduleResponseDto> findScheduleById(@PathVariable Long id) {
+
+        return new ResponseEntity<>(scheduleService.findScheduleById(id), HttpStatus.OK);
+    }
+
 }

--- a/src/main/java/com/example/schedulemanagementapi/controller/ScheduleController.java
+++ b/src/main/java/com/example/schedulemanagementapi/controller/ScheduleController.java
@@ -5,10 +5,9 @@ import com.example.schedulemanagementapi.dto.ScheduleResponseDto;
 import com.example.schedulemanagementapi.service.ScheduleService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/schedules")
@@ -25,6 +24,12 @@ public class ScheduleController {
 
         // 생성에 성공한다면 반환받은 데이터를 [201 Created]와 함께 클라이언트에게 응답
         return new ResponseEntity<>(scheduleService.saveSchedule(requestDto), HttpStatus.CREATED);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ScheduleResponseDto>> findAllSchedules() {
+
+        return new ResponseEntity<>(scheduleService.findAllSchedules(), HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/example/schedulemanagementapi/service/ScheduleService.java
+++ b/src/main/java/com/example/schedulemanagementapi/service/ScheduleService.java
@@ -3,8 +3,11 @@ package com.example.schedulemanagementapi.service;
 import com.example.schedulemanagementapi.dto.ScheduleRequestDto;
 import com.example.schedulemanagementapi.dto.ScheduleResponseDto;
 
+import java.util.List;
+
 public interface ScheduleService {
 
     ScheduleResponseDto saveSchedule(ScheduleRequestDto requestDto);
 
+    List<ScheduleResponseDto> findAllSchedules();
 }

--- a/src/main/java/com/example/schedulemanagementapi/service/ScheduleService.java
+++ b/src/main/java/com/example/schedulemanagementapi/service/ScheduleService.java
@@ -10,4 +10,6 @@ public interface ScheduleService {
     ScheduleResponseDto saveSchedule(ScheduleRequestDto requestDto);
 
     List<ScheduleResponseDto> findAllSchedules();
+
+    ScheduleResponseDto findScheduleById(Long id);
 }

--- a/src/main/java/com/example/schedulemanagementapi/service/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/schedulemanagementapi/service/ScheduleServiceImpl.java
@@ -7,6 +7,8 @@ import com.example.schedulemanagementapi.repository.ScheduleRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 public class ScheduleServiceImpl implements ScheduleService {
 
@@ -26,6 +28,15 @@ public class ScheduleServiceImpl implements ScheduleService {
         // 받아온 매핑된 Schedule 객체를 DTO로 생성하여 반환
         Schedule savedSchedule = scheduleRepository.save(schedule);
         return new ScheduleResponseDto(savedSchedule);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<ScheduleResponseDto> findAllSchedules() {
+
+        return scheduleRepository.findAll().stream()
+                .map(ScheduleResponseDto::new)
+                .toList();
     }
 
 }

--- a/src/main/java/com/example/schedulemanagementapi/service/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/schedulemanagementapi/service/ScheduleServiceImpl.java
@@ -4,8 +4,10 @@ import com.example.schedulemanagementapi.dto.ScheduleRequestDto;
 import com.example.schedulemanagementapi.dto.ScheduleResponseDto;
 import com.example.schedulemanagementapi.entity.Schedule;
 import com.example.schedulemanagementapi.repository.ScheduleRepository;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -37,6 +39,13 @@ public class ScheduleServiceImpl implements ScheduleService {
         return scheduleRepository.findAll().stream()
                 .map(ScheduleResponseDto::new)
                 .toList();
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public ScheduleResponseDto findScheduleById(Long id) {
+
+        return new ScheduleResponseDto(scheduleRepository.findById(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Does not exists id = " + id)));
     }
 
 }


### PR DESCRIPTION
1. 일정 전체 조회 기능
    - [ ] `작성자명`을 기준으로 등록된 일정 목록을 전부 조회
    - [ ] `작성자명`은 조회 조건으로 포함될 수도 있고, 포함되지 않을 수도 있습니다.
    - [x] 하나의 API로 작성해야 합니다.
    - [ ] `수정일` 기준 내림차순으로 정렬
    - [x] API 응답에 비밀번호는 제외해야 합니다.
3. 일정 단건 조회 기능
    - [x]  선택한 일정 단건의 정보를 조회할 수 있습니다.
        - [x]  일정의 고유 식별자(ID)를 사용하여 조회합니다.
    - [x]  API 응답에 `비밀번호`는 제외해야 합니다.