### PR TITLE
feat(schedule): 일정 수정 기능 추가

### DIFF
--- a/src/main/java/com/example/schedulemanagementapi/controller/ScheduleController.java
+++ b/src/main/java/com/example/schedulemanagementapi/controller/ScheduleController.java
@@ -42,4 +42,23 @@ public class ScheduleController {
         return new ResponseEntity<>(scheduleService.findScheduleById(id), HttpStatus.OK);
     }
 
+    /**
+     * <p>제목과 이름만 변경할 수 있는 명확한 기능의 역할이기 때문에</p>
+     * <p>메서드명을 직관적으로 작성하여 분리</p>
+     */
+    @PatchMapping("/{id}")
+    public ResponseEntity<ScheduleResponseDto> updateScheduleTitleAndName(
+            @PathVariable Long id,
+            @RequestBody ScheduleRequestDto requestDto
+    ) {
+
+        /*
+        제목과 이름만 변경하는 기능이지만, DTO에서 데이터를 따로 꺼내어 넘기지 않고 DTO를 넘기는 이유
+        - 안전하고, 유지보수에 유리하다.
+        - 필드가 많아지면 인자도 그에 맞춰 늘어나야 함
+          또한, Service의 비즈니스 로직까지 수정해야하기 때문
+        - DTO를 넘기면, Service 로직만 수정하면 됨
+         */
+        return new ResponseEntity<>(scheduleService.updateScheduleTitleAndName(id, requestDto), HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/example/schedulemanagementapi/entity/Schedule.java
+++ b/src/main/java/com/example/schedulemanagementapi/entity/Schedule.java
@@ -33,4 +33,13 @@ public class Schedule extends BaseEntity {
         this.password = password;
     }
 
+    // 제목 수정을 위한 Setter
+    public void updateTitle(String title) {
+        this.title = title;
+    }
+
+    // 이름 수정을 위한 Setter
+    public void updateName(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/com/example/schedulemanagementapi/service/ScheduleService.java
+++ b/src/main/java/com/example/schedulemanagementapi/service/ScheduleService.java
@@ -12,4 +12,6 @@ public interface ScheduleService {
     List<ScheduleResponseDto> findAllSchedules(String name);
 
     ScheduleResponseDto findScheduleById(Long id);
+
+    ScheduleResponseDto updateScheduleTitleAndName(Long id, ScheduleRequestDto requestDto);
 }

--- a/src/main/java/com/example/schedulemanagementapi/service/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/schedulemanagementapi/service/ScheduleServiceImpl.java
@@ -61,4 +61,34 @@ public class ScheduleServiceImpl implements ScheduleService {
         return new ScheduleResponseDto(scheduleRepository.findById(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Does not exists id = " + id)));
     }
 
+    @Transactional
+    @Override
+    public ScheduleResponseDto updateScheduleTitleAndName(
+            Long id,
+            ScheduleRequestDto requestDto
+    ) {
+
+        // 데이터 유효성 검사
+        // 비밀번호 NPE check
+        if (requestDto.getPassword() == null || requestDto.getPassword().isEmpty()) {
+            // 400 BAD REQUEST
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Password is empty");
+        }
+
+        // 해당 ID의 일정이 있는지 확인
+        Schedule schedule = scheduleRepository.findById(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Does not exists id = " + id));
+
+        // 비밀번호 일치 확인
+        if (!schedule.getPassword().equals(requestDto.getPassword())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Passwords do not match");
+        }
+
+        // Dirty Checking
+        // @Transactional이 있다면 setter만 호출해도 업데이트가 반영된다.
+        if (requestDto.getTitle() != null && !requestDto.getTitle().isBlank()) schedule.updateTitle(requestDto.getTitle());
+        if (requestDto.getName() != null && !requestDto.getName().isBlank()) schedule.updateName(requestDto.getName());
+
+        return new ScheduleResponseDto(schedule);
+    }
+
 }


### PR DESCRIPTION
- [x]  **선택한 일정 수정**
    - [x]  선택한 일정 내용 중 `일정 제목`, `작성자명` 만 수정 가능
        - [x]  서버에 일정 수정을 요청할 때 `비밀번호`를 함께 전달합니다.
        - [x]  `작성일` 은 변경할 수 없으며, `수정일` 은 수정 완료 시, 수정한 시점으로 변경되어야 합니다.
    - [x]  API 응답에 `비밀번호`는 제외해야 합니다.
    - [x] 비밀번호 일치 확인

closes #3 