### PR TITLE
feat(comment): 댓글 생성 기능 추가 #19

### DIFF
--- a/src/main/java/com/example/schedulemanagementapi/controller/CommentController.java
+++ b/src/main/java/com/example/schedulemanagementapi/controller/CommentController.java
@@ -1,0 +1,28 @@
+package com.example.schedulemanagementapi.controller;
+
+import com.example.schedulemanagementapi.dto.CommentRequestDto;
+import com.example.schedulemanagementapi.dto.CommentResponseDto;
+import com.example.schedulemanagementapi.service.CommentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/schedules/{scheduleId}/comments")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping
+    public ResponseEntity<CommentResponseDto> createComment(
+        @PathVariable Long scheduleId,
+        @RequestBody CommentRequestDto requestDto
+    ) {
+
+        return new ResponseEntity<>(commentService.saveComment(scheduleId, requestDto), HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/com/example/schedulemanagementapi/dto/CommentRequestDto.java
+++ b/src/main/java/com/example/schedulemanagementapi/dto/CommentRequestDto.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 @Getter
 public class CommentRequestDto {
 
-    private Long scheduleId;
     private String contents;
     private String name;
     private String password;

--- a/src/main/java/com/example/schedulemanagementapi/entity/Comment.java
+++ b/src/main/java/com/example/schedulemanagementapi/entity/Comment.java
@@ -40,7 +40,8 @@ public class Comment extends BaseEntity {
 
     private String password; // 비밀번호
 
-    public Comment(String contents, String name, String password) {
+    public Comment(Schedule schedule, String contents, String name, String password) {
+        this.schedule = schedule;
         this.contents = contents;
         this.name = name;
         this.password = password;

--- a/src/main/java/com/example/schedulemanagementapi/repository/CommentRepository.java
+++ b/src/main/java/com/example/schedulemanagementapi/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package com.example.schedulemanagementapi.repository;
+
+import com.example.schedulemanagementapi.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/com/example/schedulemanagementapi/service/CommentService.java
+++ b/src/main/java/com/example/schedulemanagementapi/service/CommentService.java
@@ -1,0 +1,10 @@
+package com.example.schedulemanagementapi.service;
+
+import com.example.schedulemanagementapi.dto.CommentRequestDto;
+import com.example.schedulemanagementapi.dto.CommentResponseDto;
+
+public interface CommentService {
+
+    CommentResponseDto saveComment(Long scheduleId, CommentRequestDto requestDto);
+
+}

--- a/src/main/java/com/example/schedulemanagementapi/service/CommentServiceImpl.java
+++ b/src/main/java/com/example/schedulemanagementapi/service/CommentServiceImpl.java
@@ -1,0 +1,48 @@
+package com.example.schedulemanagementapi.service;
+
+import com.example.schedulemanagementapi.dto.CommentRequestDto;
+import com.example.schedulemanagementapi.dto.CommentResponseDto;
+import com.example.schedulemanagementapi.entity.Comment;
+import com.example.schedulemanagementapi.entity.Schedule;
+import com.example.schedulemanagementapi.repository.CommentRepository;
+import com.example.schedulemanagementapi.repository.ScheduleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@RequiredArgsConstructor
+@Service
+public class CommentServiceImpl implements CommentService {
+
+    private final CommentRepository commentRepository;
+    private final ScheduleRepository scheduleRepository;
+
+    @Transactional
+    @Override
+    public CommentResponseDto saveComment(Long scheduleId, CommentRequestDto requestDto) {
+
+        // scheduleId로 일정을 조회
+        Schedule schedule = scheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Does not exists scheduleId = " + scheduleId));
+
+        // 댓글 개수 체크 (최대 10개)
+        int commentCount = schedule.getComments().size();
+        if (commentCount >= 10) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "The number of comments is up to 10.");
+        }
+
+        // 댓글 생성
+        Comment comment = new Comment(
+                schedule,
+                requestDto.getContents(),
+                requestDto.getName(),
+                requestDto.getPassword()
+        );
+
+        Comment savedComment = commentRepository.save(comment);
+        return new CommentResponseDto(savedComment);
+    }
+
+}


### PR DESCRIPTION
- [x]  **댓글 생성(댓글 작성하기)**
    - [x]  일정에 댓글을 작성할 수 있습니다.
    - [x]  댓글 생성 시, 포함되어야할 데이터
        - [x]  `댓글 내용`, `작성자명`, `비밀번호`, `작성/수정일`, `일정 고유식별자(ID)`를 저장
        - [x]  `작성/수정일`은 날짜와 시간을 모두 포함한 형태
    - [x]  각 일정의 고유 식별자(ID)를 자동으로 생성하여 관리
    - [x]  최초 생성 시, `수정일`은 `작성일`과 동일
    - [x]  `작성일`, `수정일` 필드는 `JPA Auditing`을 활용하여 적용합니다.
    - [x]  하나의 일정에는 댓글을 10개까지만 작성할 수 있습니다.
    - [x]  API 응답에 `비밀번호`는 제외해야 합니다.

closes #19 